### PR TITLE
Add random permutation to the indices.

### DIFF
--- a/src/helpers/BaseRunner.py
+++ b/src/helpers/BaseRunner.py
@@ -167,8 +167,23 @@ class BaseRunner(object):
                         collate_fn=dataset.collate_batch, pin_memory=self.pin_memory)
         for batch in tqdm(dl, leave=False, desc='Epoch {:<3}'.format(epoch), ncols=100, mininterval=1):
             batch = utils.batch_to_gpu(batch, model.device)
+            
+            # randomly shuffle the items to avoid models remembering the first item being the target
+            item_ids = batch['item_id']
+            # for each row (sample), get random indices and shuffle the original items
+            indices = torch.argsort(torch.rand(*item_ids.shape), dim=-1)                        
+            batch['item_id'] = item_ids[torch.arange(item_ids.shape[0]).unsqueeze(-1), indices]
+
             model.optimizer.zero_grad()
             out_dict = model(batch)
+
+            # shuffle the predictions back so that the prediction scores match the original order (first item is the target)
+            prediction = out_dict['prediction']
+            restored_prediction = torch.zeros(*prediction.shape).to(prediction.device)
+            # use the random indices to shuffle back
+            restored_prediction[torch.arange(item_ids.shape[0]).unsqueeze(-1), indices] = prediction   
+            out_dict['prediction'] = restored_prediction
+
             loss = model.loss(out_dict)
             loss.backward()
             model.optimizer.step()
@@ -202,7 +217,20 @@ class BaseRunner(object):
         dl = DataLoader(dataset, batch_size=self.eval_batch_size, shuffle=False, num_workers=self.num_workers,
                         collate_fn=dataset.collate_batch, pin_memory=self.pin_memory)
         for batch in tqdm(dl, leave=False, ncols=100, mininterval=1, desc='Predict'):
+            
+            # randomly shuffle the items to avoid models remembering the first item being the target
+            item_ids = batch['item_id']
+            # for each row (sample), get random indices and shuffle the original items
+            indices = torch.argsort(torch.rand(*item_ids.shape), dim=-1)
+            batch['item_id'] = item_ids[torch.arange(item_ids.shape[0]).unsqueeze(-1), indices]
+
             prediction = dataset.model(utils.batch_to_gpu(batch, dataset.model.device))['prediction']
+            # shuffle the predictions back so that the prediction scores match the original order (first item is the target)
+            restored_prediction = torch.zeros(*prediction.shape).to(prediction.device)
+            # use the random indices to shuffle back
+            restored_prediction[torch.arange(item_ids.shape[0]).unsqueeze(-1), indices] = prediction
+            prediction = restored_prediction
+
             predictions.extend(prediction.cpu().data.numpy())
         predictions = np.array(predictions)
 


### PR DESCRIPTION
Creating this pull request for Issue #43 . I have added random permutation to the `fit` function and `predict` function so that the models cannot remember the first item being the target.

I have created a new directory for this pull request because I have changed too many things in the original directory, and it might contain sensitive contents. However, I have tested the diff using the following two models and the results seem to be fine. In my original directory, the code works fine with KDA, SASRec, ComiRec and many other models. Please let me know if you observe otherwise.

```bash
python main.py --model_name TiSASRec --emb_size 64 --num_layers 1 --num_heads 1 --lr 1e-4 --l2 1e-6 --history_max 20 --dataset 'Grocery_and_Gourmet_Food'

python main.py --model_name TiMiRec --emb_size 64 --lr 1e-4 --l2 1e-6 --history_max 20 --K 6 --add_pos 1 --add_trm 1 --stage pretrain --dataset 'Grocery_and_Gourmet_Food'
```

I have added some comments to make the code easier to understand. 
